### PR TITLE
Add Tailwind plugin compatibility coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettier-plugin-wp-block-html",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-wp-block-html",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "prettier": "^3.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-wp-block-html",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Prettier plugin for HTML in WordPress Block Theme.",
   "keywords": [
     "prettier-plugin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,11 @@ export const languages: SupportLanguage[] = [
 const htmlParser = prettierHtmlParsers.html;
 const htmlPrinter = prettierHtmlPrinters.html as Printer;
 const tailwindPlugin = await loadIfExistsESM("prettier-plugin-tailwindcss");
-const tailwindHtmlParser = tailwindPlugin.parsers?.html;
+const tailwindHtmlParserEntry = tailwindPlugin.parsers?.html as unknown;
+const tailwindHtmlParser =
+  typeof tailwindHtmlParserEntry === "function"
+    ? await tailwindHtmlParserEntry()
+    : tailwindHtmlParserEntry;
 
 const wpBlockHtmlParser = {
   ...htmlParser,

--- a/test/fixtures/tailwind/input.html
+++ b/test/fixtures/tailwind/input.html
@@ -1,0 +1,7 @@
+<!-- wp:group -->
+<div class="text-red-500 container mx-auto flex px-4 sm:px-6 lg:px-8">
+<!-- wp:paragraph -->
+<p class="font-bold text-sm md:text-base text-center">Tailwind classes</p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/test/fixtures/tailwind/output.html
+++ b/test/fixtures/tailwind/output.html
@@ -1,0 +1,7 @@
+<!-- wp:group -->
+  <div class="container mx-auto flex px-4 text-red-500 sm:px-6 lg:px-8">
+    <!-- wp:paragraph -->
+      <p class="text-center text-sm font-bold md:text-base">Tailwind classes</p>
+    <!-- /wp:paragraph -->
+  </div>
+<!-- /wp:group -->

--- a/test/prettier.mjs
+++ b/test/prettier.mjs
@@ -3,9 +3,11 @@ import { join } from "node:path";
 import assert from "node:assert/strict";
 import * as prettier from "prettier";
 import * as plugin from "../dist/index.mjs";
+import * as tailwindPluginModule from "prettier-plugin-tailwindcss";
 
 const fixturesDir = new URL("./fixtures/", import.meta.url);
 const fixtureNames = await readdir(fixturesDir);
+const tailwindPlugin = tailwindPluginModule.default ?? tailwindPluginModule;
 
 for (const fixtureName of fixtureNames) {
   const fixtureDir = new URL(`${fixtureName}/`, fixturesDir);
@@ -33,6 +35,30 @@ for (const fixtureName of fixtureNames) {
     actual,
     `${join("test/fixtures", fixtureName)} is not idempotent`,
   );
+}
+
+{
+  const fixtureDir = new URL("tailwind/", fixturesDir);
+  const input = await readFile(new URL("input.html", fixtureDir), "utf8");
+  const expected = await readFile(new URL("output.html", fixtureDir), "utf8");
+
+  const pluginOrders = [
+    ["tailwind first", [tailwindPlugin, plugin]],
+    ["wp-block-html first", [plugin, tailwindPlugin]],
+  ];
+
+  for (const [label, plugins] of pluginOrders) {
+    const actual = await prettier.format(input, {
+      parser: "wp-block-html",
+      plugins,
+    });
+
+    assert.equal(
+      actual,
+      expected,
+      `prettier-plugin-tailwindcss should compose with wp-block-html: ${label}`,
+    );
+  }
 }
 
 console.log(`Formatted ${fixtureNames.length} fixture(s).`);


### PR DESCRIPTION
## Summary

- Resolve `prettier-plugin-tailwindcss` async parser factory before composing the HTML parser
- Add a Tailwind fixture that verifies class sorting still works with `wp-block-html`
- Test both plugin orders:
  - `prettier-plugin-tailwindcss` before this plugin
  - this plugin before `prettier-plugin-tailwindcss`
- Bump package version to `0.3.1`

## Verification

- `npm run build`
- `npm test`
- `npm run check`
- `npx tsc --noEmit`